### PR TITLE
change test_program INCLUDE to relative path

### DIFF
--- a/test_programs/Makefile
+++ b/test_programs/Makefile
@@ -3,7 +3,7 @@ CC=g++
 CFLAGS= -std=c++11
 #-fpic -- This is only required to build shared library 
 
-INCLUDE = -I/home/harman/ddfs/src/global
+INCLUDE = -I ../src/global
 LIBS	= -L/usr/local/lib
 RM	= /bin/rm
 


### PR DESCRIPTION
the test_program's Makefile has something to optimize.so I change the previous absolute path to relative path.